### PR TITLE
Update install command to new ember cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Usage
 
-    ember install:addon ember-meta-meta
+    ember install ember-meta-meta
 
 Set desired metas in your controller setup :
 


### PR DESCRIPTION
It solves this problem:

```
$ ember install:addon ember-meta-meta
This command has been deprecated. Please use `ember install <addonName>` instead.
```