### PR TITLE
Update ember-cli-babel to "^7.1.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "seo"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^7.1.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
@j15e, updated `ember-cli-babel` due to warning 

> DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.